### PR TITLE
Bump `kind-of`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "kind-of": "^3.1.0"
+    "kind-of": "^6.0.2"
   },
   "devDependencies": {
     "gulp-format-md": "^0.1.11",


### PR DESCRIPTION
To the latest version.  Doesn't break anything and gets rid of the `is-buffer` dependency.  Probably not a good reason.